### PR TITLE
changed interpreter to be more portable.

### DIFF
--- a/emojiget.py
+++ b/emojiget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2021 Tuncay D.
 # MIT License, see LICENSE

--- a/emojipick
+++ b/emojipick
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2021 Tuncay D.
 # MIT License, see LICENSE


### PR DESCRIPTION
`#!/usr/bin/env python3` and `#!/usr/bin/env bash` is portable for more distros (example: NixOS) since it is not guaranteed a distro/user will have `/usr/bin/bash`.

I did go ahead and package this for nixpkgs though and seems to work fine 🤠